### PR TITLE
Improve APIs 

### DIFF
--- a/encryption.go
+++ b/encryption.go
@@ -5,123 +5,126 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/base64"
-	"fmt"
-	"golang.org/x/exp/utf8string"
+	"errors"
 )
 
 type ecb struct {
-	b         cipher.Block
-	blockSize int
+	cipher         cipher.Block
 }
 
-type ecbEncrypter ecb
-
-func newECB(b cipher.Block) *ecb {
+func newECB(c cipher.Block) *ecb {
 	return &ecb{
-		b:         b,
-		blockSize: b.BlockSize(),
+		cipher:         c,
 	}
 }
 
-func NewECBEncrypter(b cipher.Block) cipher.BlockMode {
-	return (*ecbEncrypter)(newECB(b))
+func (x *ecb) BlockSize() int {
+	return x.cipher.BlockSize()
 }
 
-func (x *ecbEncrypter) BlockSize() int { return x.blockSize }
-func (x *ecbEncrypter) CryptBlocks(dst, src []byte) {
-	if len(src)%x.blockSize != 0 {
-		panic("crypto/cipher: input not full blocks")
+func (x *ecb) EncryptBlocks(dst []byte, src []byte) error {
+
+	if len(src) % x.BlockSize() != 0 {
+		return errors.New("EncryptBlocks: input not a multiple of blocksize")
 	}
+
 	if len(dst) < len(src) {
-		panic("crypto/cipher: output smaller than input")
+		return errors.New("EncryptBlocks: output buffer is too small")
 	}
+
 	for len(src) > 0 {
-		x.b.Encrypt(dst, src[:x.blockSize])
-		src = src[x.blockSize:]
-		dst = dst[x.blockSize:]
+		x.cipher.Encrypt(dst, src[:x.BlockSize()])
+		src = src[x.BlockSize():]
+		dst = dst[x.BlockSize():]
 	}
+
+	return nil
 }
-func pKCS5Padding(ciphertext []byte, blockSize int) []byte {
-	padding := blockSize - len(ciphertext)%blockSize
+
+func (x *ecb) DecryptBlocks(dst []byte, src []byte) error {
+
+	if len(src) % x.BlockSize() != 0 {
+		return errors.New("DecryptBlocks: input not a multiple of blocksize")
+	}
+
+	if len(dst) < len(src) {
+		return errors.New("DecryptBlocks: output buffer is too small")
+	}
+
+	for len(src) > 0 {
+		x.cipher.Decrypt(dst, src[:x.BlockSize()])
+		src = src[x.BlockSize():]
+		dst = dst[x.BlockSize():]
+	}
+
+	return nil
+}
+
+func (x *ecb) pkcs5Padding(ciphertext []byte) []byte {
+	padding := x.BlockSize() - len(ciphertext) % x.BlockSize()
 	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
 	return append(ciphertext, padtext...)
 }
 
-func AESEncrypt(src string, key string) []byte {
-	usableKey, _ := base64.StdEncoding.DecodeString(key)
-	block, err := aes.NewCipher(usableKey)
-	if err != nil {
-		fmt.Println("key error1", err)
-	}
-	if src == "" {
-		fmt.Println("plain content empty")
-	}
-	ecb := NewECBEncrypter(block)
-	content := []byte(utf8string.NewString(src).String())
-
-	content = pKCS5Padding(content, block.BlockSize())
-	crypted := make([]byte, len(content))
-
-	ecb.CryptBlocks(crypted, content)
-
-	return crypted
-}
-
-type ecbDecrypter ecb
-
-func (x *ecbDecrypter) BlockSize() int { return x.blockSize }
-func (x *ecbDecrypter) CryptBlocks(dst, src []byte) {
-	if len(src)%x.blockSize != 0 {
-		panic("crypto/cipher: input not full blocks")
-	}
-	if len(dst) < len(src) {
-		panic("crypto/cipher: output smaller than input")
-	}
-	for len(src) > 0 {
-		x.b.Decrypt(dst, src[:x.blockSize])
-		src = src[x.blockSize:]
-		dst = dst[x.blockSize:]
-	}
-}
-
-func NewECBDecrypter(b cipher.Block) cipher.BlockMode {
-	return (*ecbDecrypter)(newECB(b))
-}
-
-func pKCS5UnPadding(origData []byte) []byte {
+func (x *ecb) pkcs5UnPadding(origData []byte) []byte {
 	length := len(origData)
 	unpadding := int(origData[length-1])
 	return origData[:(length - unpadding)]
 }
 
-func AESDecrypt(crypt string, key string) string {
-	usableKey, _ := base64.StdEncoding.DecodeString(key)
+func AESEncrypt(clearText []byte, key []byte) ([]byte, error) {
 
-	block, err := aes.NewCipher(usableKey)
+	cipher, err := aes.NewCipher(key)
+
 	if err != nil {
-		fmt.Println("key error1", err)
+		return nil, err
 	}
-	if len(crypt) == 0 {
-		fmt.Println("plain content empty")
+
+	if len(clearText) == 0 {
+		return nil, errors.New("AESEncrypt: Cleartext length is 0")
 	}
-	usableCrypt, _ := base64.StdEncoding.DecodeString(crypt)
 
-	ecb := NewECBDecrypter(block)
-	decrypted := make([]byte, len(usableCrypt))
-	ecb.CryptBlocks(decrypted, []byte(usableCrypt))
+	ecb := newECB(cipher)
 
-	padded := pKCS5UnPadding(decrypted)
+	padded := ecb.pkcs5Padding(clearText)
+	cipherText := make([]byte, len(padded))
 
-	return utf8string.NewString(string(padded)).String()
+	ecb.EncryptBlocks(cipherText, padded)
+
+	return cipherText, nil
 }
 
-func Encrypt(data string, key string) string {
+func AESDecrypt(cipherText []byte, key []byte) ([]byte, error) {
+	cipher, err := aes.NewCipher(key)
 
-	temp := AESEncrypt(data, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(cipherText) == 0 {
+		return nil, errors.New("AESDecrypt: Ciphertext length is 0")
+	}
+
+	ecb := newECB(cipher)
+	decrypted := make([]byte, len(cipherText))
+	ecb.DecryptBlocks(decrypted, []byte(cipherText))
+
+	unpadded := ecb.pkcs5UnPadding(decrypted)
+
+	return unpadded, nil
+}
+
+//DEPRECIATED
+func Encrypt(data string, key string) string {
+	usableKey, _ := base64.StdEncoding.DecodeString(key)
+	temp, _ := AESEncrypt([]byte(data), usableKey)
 	return base64.StdEncoding.EncodeToString(temp)
 }
 
-func Decrypt(data string, key string) string {
-	temp := AESDecrypt(data, key)
+//DEPRECIATED
+func Decrypt(data string, key string) []byte {
+	usableKey, _ := base64.StdEncoding.DecodeString(key)
+	usableCrypt, _ := base64.StdEncoding.DecodeString(data)
+	temp, _ := AESDecrypt(usableCrypt, usableKey)
 	return temp
 }

--- a/encryption.go
+++ b/encryption.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
-	"encoding/base64"
 	"errors"
 )
 
@@ -112,19 +111,4 @@ func AESDecrypt(cipherText []byte, key []byte) ([]byte, error) {
 	unpadded := ecb.pkcs5UnPadding(decrypted)
 
 	return unpadded, nil
-}
-
-//DEPRECIATED
-func Encrypt(data string, key string) string {
-	usableKey, _ := base64.StdEncoding.DecodeString(key)
-	temp, _ := AESEncrypt([]byte(data), usableKey)
-	return base64.StdEncoding.EncodeToString(temp)
-}
-
-//DEPRECIATED
-func Decrypt(data string, key string) []byte {
-	usableKey, _ := base64.StdEncoding.DecodeString(key)
-	usableCrypt, _ := base64.StdEncoding.DecodeString(data)
-	temp, _ := AESDecrypt(usableCrypt, usableKey)
-	return temp
 }

--- a/encryption.go
+++ b/encryption.go
@@ -1,0 +1,127 @@
+package block_io_go
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"fmt"
+	"golang.org/x/exp/utf8string"
+)
+
+type ecb struct {
+	b         cipher.Block
+	blockSize int
+}
+
+type ecbEncrypter ecb
+
+func newECB(b cipher.Block) *ecb {
+	return &ecb{
+		b:         b,
+		blockSize: b.BlockSize(),
+	}
+}
+
+func NewECBEncrypter(b cipher.Block) cipher.BlockMode {
+	return (*ecbEncrypter)(newECB(b))
+}
+
+func (x *ecbEncrypter) BlockSize() int { return x.blockSize }
+func (x *ecbEncrypter) CryptBlocks(dst, src []byte) {
+	if len(src)%x.blockSize != 0 {
+		panic("crypto/cipher: input not full blocks")
+	}
+	if len(dst) < len(src) {
+		panic("crypto/cipher: output smaller than input")
+	}
+	for len(src) > 0 {
+		x.b.Encrypt(dst, src[:x.blockSize])
+		src = src[x.blockSize:]
+		dst = dst[x.blockSize:]
+	}
+}
+func pKCS5Padding(ciphertext []byte, blockSize int) []byte {
+	padding := blockSize - len(ciphertext)%blockSize
+	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
+	return append(ciphertext, padtext...)
+}
+
+func AESEncrypt(src string, key string) []byte {
+	usableKey, _ := base64.StdEncoding.DecodeString(key)
+	block, err := aes.NewCipher(usableKey)
+	if err != nil {
+		fmt.Println("key error1", err)
+	}
+	if src == "" {
+		fmt.Println("plain content empty")
+	}
+	ecb := NewECBEncrypter(block)
+	content := []byte(utf8string.NewString(src).String())
+
+	content = pKCS5Padding(content, block.BlockSize())
+	crypted := make([]byte, len(content))
+
+	ecb.CryptBlocks(crypted, content)
+
+	return crypted
+}
+
+type ecbDecrypter ecb
+
+func (x *ecbDecrypter) BlockSize() int { return x.blockSize }
+func (x *ecbDecrypter) CryptBlocks(dst, src []byte) {
+	if len(src)%x.blockSize != 0 {
+		panic("crypto/cipher: input not full blocks")
+	}
+	if len(dst) < len(src) {
+		panic("crypto/cipher: output smaller than input")
+	}
+	for len(src) > 0 {
+		x.b.Decrypt(dst, src[:x.blockSize])
+		src = src[x.blockSize:]
+		dst = dst[x.blockSize:]
+	}
+}
+
+func NewECBDecrypter(b cipher.Block) cipher.BlockMode {
+	return (*ecbDecrypter)(newECB(b))
+}
+
+func pKCS5UnPadding(origData []byte) []byte {
+	length := len(origData)
+	unpadding := int(origData[length-1])
+	return origData[:(length - unpadding)]
+}
+
+func AESDecrypt(crypt string, key string) string {
+	usableKey, _ := base64.StdEncoding.DecodeString(key)
+
+	block, err := aes.NewCipher(usableKey)
+	if err != nil {
+		fmt.Println("key error1", err)
+	}
+	if len(crypt) == 0 {
+		fmt.Println("plain content empty")
+	}
+	usableCrypt, _ := base64.StdEncoding.DecodeString(crypt)
+
+	ecb := NewECBDecrypter(block)
+	decrypted := make([]byte, len(usableCrypt))
+	ecb.CryptBlocks(decrypted, []byte(usableCrypt))
+
+	padded := pKCS5UnPadding(decrypted)
+
+	return utf8string.NewString(string(padded)).String()
+}
+
+func Encrypt(data string, key string) string {
+
+	temp := AESEncrypt(data, key)
+	return base64.StdEncoding.EncodeToString(temp)
+}
+
+func Decrypt(data string, key string) string {
+	temp := AESDecrypt(data, key)
+	return temp
+}

--- a/examples/sweep/go.mod
+++ b/examples/sweep/go.mod
@@ -1,0 +1,11 @@
+module github.com/BlockIo/block_io-go/examples/sweep
+
+go 1.12
+
+require (
+	github.com/BlockIo/block_io-go v0.0.0-20200811042616-c6af813ecc4a
+	github.com/go-resty/resty/v2 v2.3.0
+	github.com/joho/godotenv v1.3.0
+)
+
+replace github.com/BlockIo/block_io-go => ../../

--- a/examples/sweep/go.sum
+++ b/examples/sweep/go.sum
@@ -3,6 +3,8 @@ github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQj
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2uts=
+github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
@@ -22,10 +24,9 @@ github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/piotrnar/gocoin v0.0.0-20200822175514-67551fabbaa9 h1:F90SW3CMyUK5vVvJe8IZ0GaR/w1PCmxsHpzfrbVFIDs=
-github.com/piotrnar/gocoin v0.0.0-20200822175514-67551fabbaa9/go.mod h1:sW6i99ojgdRHcz53PCjyEeoTEDFh9dfP5iiEIiNfcaM=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/examples/sweep/go.sum
+++ b/examples/sweep/go.sum
@@ -10,9 +10,13 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/go-resty/resty/v2 v2.3.0 h1:JOOeAvjSlapTT92p8xiS19Zxev1neGikoHsXJeOq8So=
+github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4HmxLBDwaroHU=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -26,10 +30,13 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rB
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20200513185701-a91f0712d120 h1:EZ3cVSzKOlJxAd8e8YAJ7no8nNypTxexh/YE/xW3ZEY=
+golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/examples/sweep/sweep.go
+++ b/examples/sweep/sweep.go
@@ -10,10 +10,7 @@ import (
 )
 
 func main() {
-	err := godotenv.Load(".env")
-	if err != nil {
-		log.Fatalf("Error loading .env file")
-	}
+	godotenv.Load(".env")
 
 	apiKey := os.Getenv("API_KEY")
 	toAddr := os.Getenv("TO_ADDRESS")

--- a/examples/sweep/sweep.go
+++ b/examples/sweep/sweep.go
@@ -33,7 +33,7 @@ func main() {
 	fmt.Println("Raw sweep response: ")
 	fmt.Println(rawSweepResponse)
 
-	sweepData, sweepDataErr := blockio.ParseResponseData(rawSweepResponse)
+	sweepData, sweepDataErr := blockio.ParseResponseData(rawSweepResponse.String())
 
 	if sweepDataErr != nil {
 		log.Fatal(sweepDataErr)

--- a/examples/sweep/sweep.go
+++ b/examples/sweep/sweep.go
@@ -30,7 +30,7 @@ func main() {
 		}).Post("https://block.io/api/v2/sweep_from_address?api_key=" + apiKey)
 
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	fmt.Println("Raw sweep response: ")
@@ -39,13 +39,13 @@ func main() {
 	sweepData, sweepDataErr := blockio.ParseResponseData(rawSweepResponse)
 
 	if sweepDataErr != nil {
-		panic(sweepDataErr)
+		log.Fatal(sweepDataErr)
 	}
 
 	signatureReq, signSweepReqErr := blockio.SignSweepRequest(privKey, sweepData)
 
 	if signSweepReqErr != nil {
-		panic(signSweepReqErr)
+		log.Fatal(signSweepReqErr)
 	}
 
 	signAndFinalizeRes, err := restClient.R().

--- a/examples/withdraw/go.mod
+++ b/examples/withdraw/go.mod
@@ -1,0 +1,11 @@
+module github.com/BlockIo/block_io-go/examples/withdraw
+
+go 1.12
+
+require (
+	github.com/BlockIo/block_io-go v0.0.0-20200811042616-c6af813ecc4a
+	github.com/go-resty/resty/v2 v2.3.0
+	github.com/joho/godotenv v1.3.0
+)
+
+replace github.com/BlockIo/block_io-go => ../../

--- a/examples/withdraw/go.sum
+++ b/examples/withdraw/go.sum
@@ -3,6 +3,8 @@ github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQj
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2uts=
+github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
@@ -22,10 +24,9 @@ github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/piotrnar/gocoin v0.0.0-20200822175514-67551fabbaa9 h1:F90SW3CMyUK5vVvJe8IZ0GaR/w1PCmxsHpzfrbVFIDs=
-github.com/piotrnar/gocoin v0.0.0-20200822175514-67551fabbaa9/go.mod h1:sW6i99ojgdRHcz53PCjyEeoTEDFh9dfP5iiEIiNfcaM=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/examples/withdraw/go.sum
+++ b/examples/withdraw/go.sum
@@ -10,9 +10,13 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/go-resty/resty/v2 v2.3.0 h1:JOOeAvjSlapTT92p8xiS19Zxev1neGikoHsXJeOq8So=
+github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4HmxLBDwaroHU=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -26,10 +30,13 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rB
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20200513185701-a91f0712d120 h1:EZ3cVSzKOlJxAd8e8YAJ7no8nNypTxexh/YE/xW3ZEY=
+golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/examples/withdraw/withdraw.go
+++ b/examples/withdraw/withdraw.go
@@ -27,7 +27,7 @@ func main() {
 	}).Post("https://block.io/api/v2/withdraw?api_key=" + apiKey)
 
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	fmt.Println("Raw withdraw response: ")
@@ -36,13 +36,13 @@ func main() {
 	withdrawData, withdrawDataErr := blockio.ParseResponseData(rawWithdrawResponse)
 
 	if withdrawDataErr != nil {
-		panic(withdrawDataErr)
+		log.Fatal(withdrawDataErr)
 	}
 
 	signatureReq, signWithdrawReqErr := blockio.SignWithdrawRequest(pin, withdrawData)
 
 	if signWithdrawReqErr != nil {
-		panic(signWithdrawReqErr)
+		log.Fatal(signWithdrawReqErr)
 	}
 
 	signAndFinalizeRes, err := restClient.R().

--- a/examples/withdraw/withdraw.go
+++ b/examples/withdraw/withdraw.go
@@ -10,10 +10,7 @@ import (
 )
 
 func main() {
-	err := godotenv.Load(".env")
-	if err != nil {
-		log.Fatalf("Error loading .env file")
-	}
+	godotenv.Load(".env")
 
 	apiKey := os.Getenv("API_KEY")
 	pin := os.Getenv("PIN")

--- a/examples/withdraw/withdraw.go
+++ b/examples/withdraw/withdraw.go
@@ -30,7 +30,7 @@ func main() {
 	fmt.Println("Raw withdraw response: ")
 	fmt.Println(rawWithdrawResponse)
 
-	withdrawData, withdrawDataErr := blockio.ParseResponseData(rawWithdrawResponse)
+	withdrawData, withdrawDataErr := blockio.ParseResponseData(rawWithdrawResponse.String())
 
 	if withdrawDataErr != nil {
 		log.Fatal(withdrawDataErr)

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,6 @@ go 1.12
 
 require (
 	github.com/btcsuite/btcd v0.20.1-beta
-	github.com/go-resty/resty/v2 v2.3.0
-	github.com/joho/godotenv v1.3.0
 	github.com/piotrnar/gocoin v0.0.0-20200822175514-67551fabbaa9
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
-	golang.org/x/exp v0.0.0-20200821190819-94841d0725da
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/btcsuite/btcd v0.20.1-beta
-	github.com/piotrnar/gocoin v0.0.0-20200822175514-67551fabbaa9
+	github.com/btcsuite/btcutil v1.0.2
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQj
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2uts=
+github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
@@ -18,10 +20,9 @@ github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/piotrnar/gocoin v0.0.0-20200822175514-67551fabbaa9 h1:F90SW3CMyUK5vVvJe8IZ0GaR/w1PCmxsHpzfrbVFIDs=
-github.com/piotrnar/gocoin v0.0.0-20200822175514-67551fabbaa9/go.mod h1:sW6i99ojgdRHcz53PCjyEeoTEDFh9dfP5iiEIiNfcaM=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/helper.go
+++ b/helper.go
@@ -98,14 +98,6 @@ func SHA256_hash(ba []byte) []byte {
 	return sha[:]
 }
 
-func HexStringToByteArray(hexString string) []byte {
-	hexed, err := hex.DecodeString(hexString)
-	if err != nil {
-		return nil
-	}
-	return hexed
-}
-
 type ecb struct {
 	b         cipher.Block
 	blockSize int

--- a/helper.go
+++ b/helper.go
@@ -45,7 +45,7 @@ func ParseResponseData(res *resty.Response) (SignatureData, error){
 
 func ExtractKeyFromEncryptedPassphrase(EncryptedData string, B64Key string) string {
 	Decrypted := Decrypt(EncryptedData,B64Key)
-	Unhexlified, err := hex.DecodeString(Decrypted)
+	Unhexlified, err := hex.DecodeString(string(Decrypted))
 
 	if err != nil {
 		log.Fatal(errors.New("Unhexlified Error"))
@@ -58,7 +58,7 @@ func ExtractKeyFromEncryptedPassphrase(EncryptedData string, B64Key string) stri
 
 func ExtractPubKeyFromEncryptedPassphrase(EncryptedData string, B64Key string) string {
 	Decrypted := Decrypt(EncryptedData,B64Key)
-	Unhexlified, err := hex.DecodeString(Decrypted)
+	Unhexlified, err := hex.DecodeString(string(Decrypted))
 
 	if err != nil {
 		log.Fatal(errors.New("Unhexlified Error"))

--- a/helper.go
+++ b/helper.go
@@ -1,9 +1,6 @@
 package block_io_go
 
 import (
-	"bytes"
-	"crypto/aes"
-	"crypto/cipher"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -14,7 +11,6 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/piotrnar/gocoin/lib/btc"
 	"golang.org/x/crypto/pbkdf2"
-	"golang.org/x/exp/utf8string"
 	"log"
 )
 
@@ -96,121 +92,4 @@ func PinToAesKey(pin string) string {
 func SHA256_hash(ba []byte) []byte {
 	sha := sha256.Sum256(ba)
 	return sha[:]
-}
-
-type ecb struct {
-	b         cipher.Block
-	blockSize int
-}
-
-type ecbEncrypter ecb
-
-func newECB(b cipher.Block) *ecb {
-	return &ecb{
-		b:         b,
-		blockSize: b.BlockSize(),
-	}
-}
-
-func NewECBEncrypter(b cipher.Block) cipher.BlockMode {
-	return (*ecbEncrypter)(newECB(b))
-}
-
-func (x *ecbEncrypter) BlockSize() int { return x.blockSize }
-func (x *ecbEncrypter) CryptBlocks(dst, src []byte) {
-	if len(src)%x.blockSize != 0 {
-		panic("crypto/cipher: input not full blocks")
-	}
-	if len(dst) < len(src) {
-		panic("crypto/cipher: output smaller than input")
-	}
-	for len(src) > 0 {
-		x.b.Encrypt(dst, src[:x.blockSize])
-		src = src[x.blockSize:]
-		dst = dst[x.blockSize:]
-	}
-}
-func pKCS5Padding(ciphertext []byte, blockSize int) []byte {
-	padding := blockSize - len(ciphertext)%blockSize
-	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
-	return append(ciphertext, padtext...)
-}
-
-func AESEncrypt(src string, key string) []byte {
-	usableKey, _ := base64.StdEncoding.DecodeString(key)
-	block, err := aes.NewCipher(usableKey)
-	if err != nil {
-		fmt.Println("key error1", err)
-	}
-	if src == "" {
-		fmt.Println("plain content empty")
-	}
-	ecb := NewECBEncrypter(block)
-	content := []byte(utf8string.NewString(src).String())
-
-	content = pKCS5Padding(content, block.BlockSize())
-	crypted := make([]byte, len(content))
-
-	ecb.CryptBlocks(crypted, content)
-
-	return crypted
-}
-
-type ecbDecrypter ecb
-
-func (x *ecbDecrypter) BlockSize() int { return x.blockSize }
-func (x *ecbDecrypter) CryptBlocks(dst, src []byte) {
-	if len(src)%x.blockSize != 0 {
-		panic("crypto/cipher: input not full blocks")
-	}
-	if len(dst) < len(src) {
-		panic("crypto/cipher: output smaller than input")
-	}
-	for len(src) > 0 {
-		x.b.Decrypt(dst, src[:x.blockSize])
-		src = src[x.blockSize:]
-		dst = dst[x.blockSize:]
-	}
-}
-
-func NewECBDecrypter(b cipher.Block) cipher.BlockMode {
-	return (*ecbDecrypter)(newECB(b))
-}
-
-func pKCS5UnPadding(origData []byte) []byte {
-	length := len(origData)
-	unpadding := int(origData[length-1])
-	return origData[:(length - unpadding)]
-}
-
-func AESDecrypt(crypt string, key string) string {
-	usableKey, _ := base64.StdEncoding.DecodeString(key)
-
-	block, err := aes.NewCipher(usableKey)
-	if err != nil {
-		fmt.Println("key error1", err)
-	}
-	if len(crypt) == 0 {
-		fmt.Println("plain content empty")
-	}
-	usableCrypt, _ := base64.StdEncoding.DecodeString(crypt)
-
-	ecb := NewECBDecrypter(block)
-	decrypted := make([]byte, len(usableCrypt))
-	ecb.CryptBlocks(decrypted, []byte(usableCrypt))
-
-	padded := pKCS5UnPadding(decrypted)
-
-	return utf8string.NewString(string(padded)).String()
-}
-
-func Encrypt(data string, key string) string {
-
-	temp := AESEncrypt(data, key)
-	return base64.StdEncoding.EncodeToString(temp)
-}
-
-func Decrypt(data string, key string) string {
-	temp := AESDecrypt(data, key)
-	return temp
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,8 +1,8 @@
 package block_io_go
 
 import (
-	"encoding/hex"
 	"testing"
+	"encoding/base64"
 )
 
 var pin string
@@ -17,33 +17,29 @@ func HelperSetup() {
 	controlCipherText = "7HTfNBYJjq09+vi8hTQhy6lCp3IHv5rztNnKCJ5RB7cSL+NjHrFVv1jl7qkxJsOg";
 }
 
-func TestSha256(t *testing.T) {
-	HelperSetup()
-	controlData := "5f78c33274e43fa9de5659265c1d917e25c03722dcb0b8d27db8d5feaa813953";
-	testData := "deadbeef";
-	bytes, _ := hex.DecodeString(testData);
-	shaData := hex.EncodeToString(SHA256_hash(bytes));
-	if shaData != controlData {
-		t.Error("SHA256 not returning correct output")
-	}
-}
-
 func TestPinToAes(t *testing.T) {
 	var controlData = "0EeMOVtm5YihUYzdCNgleqIUWkwgvNBcRmr7M0t9GOc=";
+	HelperSetup()
 	if aesKey != controlData {
 		t.Error("PinToAes not returning correct output")
 	}
 }
 
 func TestEncrypt(t *testing.T) {
-	encryptedData := Encrypt(controlClearText, aesKey);
-	if encryptedData != controlCipherText {
+	usableKey, _ := base64.StdEncoding.DecodeString(aesKey)
+	//TODO test for error
+	encryptedData, _ := AESEncrypt([]byte(controlClearText), usableKey);
+	base64Data := base64.StdEncoding.EncodeToString(encryptedData)
+	if base64Data != controlCipherText {
 		t.Error("Encrypt not returning correct output")
 	}
 }
 
 func TestDecrypt(t *testing.T) {
-	decryptedData := Decrypt(controlCipherText, aesKey)
+	usableKey, _ := base64.StdEncoding.DecodeString(aesKey)
+	usableCrypt, _ := base64.StdEncoding.DecodeString(controlCipherText)
+	//TODO test for error
+	decryptedData, _ := AESDecrypt(usableCrypt, usableKey)
 	string := string(decryptedData)
 	if string != controlClearText {
 		t.Error("Decrypt not returning correct output")

--- a/helper_test.go
+++ b/helper_test.go
@@ -43,8 +43,9 @@ func TestEncrypt(t *testing.T) {
 }
 
 func TestDecrypt(t *testing.T) {
-	decryptedData := Decrypt(controlCipherText, aesKey);
-	if decryptedData != controlClearText {
+	decryptedData := Decrypt(controlCipherText, aesKey)
+	string := string(decryptedData)
+	if string != controlClearText {
 		t.Error("Decrypt not returning correct output")
 	}
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -21,7 +21,8 @@ func TestSha256(t *testing.T) {
 	HelperSetup()
 	controlData := "5f78c33274e43fa9de5659265c1d917e25c03722dcb0b8d27db8d5feaa813953";
 	testData := "deadbeef";
-	shaData := hex.EncodeToString(SHA256_hash(HexStringToByteArray(testData)));
+	bytes, _ := hex.DecodeString(testData);
+	shaData := hex.EncodeToString(SHA256_hash(bytes));
 	if shaData != controlData {
 		t.Error("SHA256 not returning correct output")
 	}

--- a/key.go
+++ b/key.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"github.com/piotrnar/gocoin/lib/btc"
 	"github.com/btcsuite/btcd/btcec"
-	"golang.org/x/exp/utf8string"
 	"log"
 )
 
@@ -80,12 +79,6 @@ func FromWIF(privKey string) (*ECKey, error) {
 	return eckey, nil
 }
 
-//DEPRECIATED
-func PubKeyFromWIF(privKey string) string {
-	ecKey, _ := FromWIF(privKey)
-	return ecKey.PublicKeyHex()
-}
-
 func ExtractKeyFromPassphrase(HexPass string) *ECKey {
 	Unhexlified, err := hex.DecodeString(HexPass)
 
@@ -98,28 +91,7 @@ func ExtractKeyFromPassphrase(HexPass string) *ECKey {
 }
 
 func ExtractKeyFromPassphraseString(pass string) *ECKey {
-	password := []byte(utf8string.NewString(pass).String())
+	password := []byte(pass)
 	hashed := sha256.Sum256(password)
 	return NewECKey(hashed, true)
-}
-
-//DEPRECIATED
-func ExtractPubKeyFromPassphraseString(pass string) string {
-	return ExtractKeyFromPassphraseString(pass).PublicKeyHex()
-}
-
-//DEPRECIATED
-func ExtractPubKeyFromPassphrase(HexPass string) string {
-	Unhexlified, err := hex.DecodeString(HexPass)
-
-	if err != nil {
-		log.Fatal(errors.New("Unhexlified Error"))
-	}
-
-	Hashed := sha256.Sum256(Unhexlified)
-	UsableHashed := Hashed[:]
-
-	result := btc.PublicFromPrivate(UsableHashed, true)
-
-	return hex.EncodeToString(result)
 }

--- a/key_test.go
+++ b/key_test.go
@@ -31,12 +31,17 @@ func Setup() {
 	controlPubKeyFromWif = "024988bae7e0ade83cb1b6eb0fd81e6161f6657ad5dd91d216fbeab22aea3b61a0";
 	controlSignedDataWifKey = "3045022100aec97f7ad7a9831d583ca157284a68706a6ac4e76d6c9ee33adce6227a40e675022008894fb35020792c01443d399d33ffceb72ac1d410b6dcb9e31dcc71e6c49e92";
 	controlSignedDataPassphraseKey = "30450221009a68321e071c94e25484e26435639f00d23ef3fbe9c529c3347dc061f562530c0220134d3159098950b81b678f9e3b15e100f5478bb45345d3243df41ae616e70032";
-	privKeyFromWif, _ = FromWIF(wif)
-	pubKeyFromWif = PubKeyFromWIF(wif)
-	privKeyFromPassphrase = ExtractKeyFromPassphrase(passphrase)
-	pubKeyFromPassphrase = ExtractPubKeyFromPassphrase(passphrase)
-	signedDataWifKey = SignInputs(privKeyFromWif, dataToSign)
-	signedDataPassphraseKey = SignInputs(privKeyFromPassphrase, dataToSign)
+
+	ecKeyFromWif, _ := FromWIF(wif)
+	privKeyFromWif = ecKeyFromWif.PrivateKeyHex()
+	pubKeyFromWif = ecKeyFromWif.PublicKeyHex()
+
+	ecKeyFromPassphrase := ExtractKeyFromPassphrase(passphrase)
+	privKeyFromPassphrase = ecKeyFromPassphrase.PrivateKeyHex()
+	pubKeyFromPassphrase = ecKeyFromPassphrase.PublicKeyHex()
+
+	signedDataWifKey, _ = SignInputs(ecKeyFromWif, dataToSign)
+	signedDataPassphraseKey, _ = SignInputs(ecKeyFromPassphrase, dataToSign)
 }
 
 func TestPrivKeyFromWif(t *testing.T) {

--- a/sign_request.go
+++ b/sign_request.go
@@ -55,12 +55,12 @@ func SignWithdrawRequest(pin string, withdrawData SignatureData) (string, error)
 	return string(signAndFinalizeReq), nil
 }
 
-func SignSweepRequest(privKey string, sweepReqData SignatureData) (string, error) {
+func SignSweepRequest(eckey *ECKey, sweepReqData SignatureData) (string, error) {
 	if sweepReqData.ReferenceID == "" {
 		return "", errors.New("invalid sweep response")
 	}
-	keyFromWif, _ := FromWIF(privKey)
-	signedSweepReqData := signRequest(keyFromWif, sweepReqData)
+
+	signedSweepReqData := signRequest(eckey, sweepReqData)
 	signAndFinalizeReq, err := json.Marshal(signedSweepReqData)
 	if err != nil {
 		return "", err

--- a/sign_request.go
+++ b/sign_request.go
@@ -2,8 +2,14 @@ package block_io_go
 
 import (
 	"encoding/json"
+	"encoding/hex"
 	"errors"
 )
+
+func SignInputs(ecKey *ECKey, DataToSign string) (string, error) {
+	messageHash, _ := hex.DecodeString(DataToSign)
+	return ecKey.SignHex(messageHash)
+}
 
 func signRequest(ecKey *ECKey, reqData SignatureData) SignatureData {
 


### PR DESCRIPTION
- Restructure `ecb` around a set of API rules:
  - Functions shall exclusively take []byte data
  - Functions shall exclusively return []byte data
  - Functions shall return errors
  - Functions shall not print anything to console
- Introduce `ECKey` struct
- Reduce the amount of serialization between low-level calls
- Remove panic and error printing in favor of error returning
- Remove gocoin because of license
- Remove unneeded dependencies

