### PR TITLE
Remove error obscuring in ECKey:ExtractKeyFromPassphrase()

### DIFF
--- a/examples/dtrust/dtrust.go
+++ b/examples/dtrust/dtrust.go
@@ -32,9 +32,9 @@ func main(){
 	// create the private key objects for each private key
 	// NOTE: in production environments you'll do this elsewhere
 	privKeys := []*blockio.ECKey{
-		blockio.ExtractKeyFromPassphraseString("verysecretkey1"),
-		blockio.ExtractKeyFromPassphraseString("verysecretkey2"),
-		blockio.ExtractKeyFromPassphraseString("verysecretkey3"),
+		blockio.DeriveKeyFromString("verysecretkey1"),
+		blockio.DeriveKeyFromString("verysecretkey2"),
+		blockio.DeriveKeyFromString("verysecretkey3"),
 	}
 
 	// populate our pubkeys array from the keys we just generated

--- a/helper.go
+++ b/helper.go
@@ -78,14 +78,7 @@ func ExtractKeyFromEncryptedPassphrase(encryptedData string, b64Key string) (*EC
 		return nil, decryptErr
 	}
 
-	seed, hexSeedErr := hex.DecodeString(string(clearText))
-	if hexSeedErr != nil {
-		return nil, hexSeedErr
-	}
-
-	privKey := sha256.Sum256(seed)
-	ecKey := NewECKey(privKey, true)
-	return ecKey, nil
+	return DeriveKeyFromHex(string(clearText))
 }
 
 func PinToAesKey(pin string) string {

--- a/key.go
+++ b/key.go
@@ -3,7 +3,6 @@ package block_io_go
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcutil"
 	"log"
@@ -68,19 +67,33 @@ func FromWIF(strWif string) (*ECKey, error) {
 	return eckey, nil
 }
 
-func ExtractKeyFromPassphrase(HexPass string) *ECKey {
-	Unhexlified, err := hex.DecodeString(HexPass)
+func DeriveKeyFromHex(hexPass string) (*ECKey, error) {
+	unhexlified, err := hex.DecodeString(hexPass)
 
 	if err != nil {
-		log.Fatal(errors.New("Unhexlified Error"))
+		return nil, err
 	}
 
-	hashed := sha256.Sum256(Unhexlified)
-	return NewECKey(hashed, true)
+	hashed := sha256.Sum256(unhexlified)
+	return NewECKey(hashed, true), nil
 }
 
-func ExtractKeyFromPassphraseString(pass string) *ECKey {
+func DeriveKeyFromString(pass string) *ECKey {
 	password := []byte(pass)
 	hashed := sha256.Sum256(password)
 	return NewECKey(hashed, true)
+}
+
+//DEPRECIATED: Please use DeriveKeyFromHex
+func ExtractKeyFromPassphrase(hexPass string) *ECKey {
+	key, err := DeriveKeyFromHex(hexPass)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return key
+}
+
+//DEPRECIATED: Please use DeriveKeyFromString
+func ExtractKeyFromPassphraseString(pass string) *ECKey {
+	return DeriveKeyFromString(pass)
 }

--- a/key_test.go
+++ b/key_test.go
@@ -36,7 +36,7 @@ func Setup() {
 	privKeyFromWif = ecKeyFromWif.PrivateKeyHex()
 	pubKeyFromWif = ecKeyFromWif.PublicKeyHex()
 
-	ecKeyFromPassphrase := ExtractKeyFromPassphrase(passphrase)
+	ecKeyFromPassphrase, _ := DeriveKeyFromHex(passphrase)
 	privKeyFromPassphrase = ecKeyFromPassphrase.PrivateKeyHex()
 	pubKeyFromPassphrase = ecKeyFromPassphrase.PublicKeyHex()
 

--- a/sign_request_test.go
+++ b/sign_request_test.go
@@ -226,8 +226,8 @@ func TestSignRequestJsonWithKeys(t *testing.T){
 	//////// SETUP ////////
 	// Extract ECKeys from passphrase
 	keys := []*ECKey{
-		ExtractKeyFromPassphraseString("verysecretkey2"),
-		ExtractKeyFromPassphraseString("verysecretkey3"),
+		DeriveKeyFromString("verysecretkey2"),
+		DeriveKeyFromString("verysecretkey3"),
 	}
 
 	// read JSON input


### PR DESCRIPTION
- Create new replacement methods for both functions:
  - ExtractKeyFromPassphrase -> DeriveKeyFromHex
  - ExtractKeyFromPassphraseString -> DeriveKeyFromString
- Fix error propagation in DeriveKeyFromHex
- Rewire existing functions to use new ones and mark DEPRECIATED
- Update all calls to ExtractKey*